### PR TITLE
refactor: update types to 2.1.0 breaking changes

### DIFF
--- a/Variant-Kyoto/app/build.gradle.kts
+++ b/Variant-Kyoto/app/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
 
     // Bitcoin Development Kit
-    implementation("org.bitcoindevkit:bdk-android:1.2.0")
+    implementation("org.bitcoindevkit:bdk-android:2.2.0")
 
     // QR codes
     implementation("com.google.zxing:core:3.5.3")

--- a/Variant-Kyoto/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/viewmodels/WalletViewModel.kt
+++ b/Variant-Kyoto/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/viewmodels/WalletViewModel.kt
@@ -103,27 +103,14 @@ internal class WalletViewModel(
 
         kyotoCoroutineScope.launch {
             while (wallet.kyotoClient != null) {
-                val nextLog: org.bitcoindevkit.Log = wallet.kyotoClient!!.nextLog()
-                Log.i("Kyoto", "LOG: $nextLog")
-                val logString = nextLog.toString()
-                if (logString.contains("Compact Filter Headers")) {
-                    val regex = Regex("""\d+/\d+""")
+                val nextInfo = wallet.kyotoClient!!.nextInfo()
+                Log.i("Kyoto", "LOG: $nextInfo")
+                    val lastNumber = wallet.getLastCheckpoint().height.toInt()
 
-                    val lastNumber = regex.findAll(logString)
-                        .lastOrNull()
-                        ?.value
-                        ?.split("/")
-                        ?.getOrNull(1)
-                        ?.toIntOrNull()
-
-                    if (lastNumber != null) {
-                        if (lastNumber > latestBlock) {
-                            latestBlock = lastNumber
-                            // Log.i("Kyoto", "New block: $latestBlock")
-                            updateLatestBlock(latestBlock.toUInt())
-                            showSnackbar("New block mined! $latestBlock \uD83C\uDF89\uD83C\uDF89")
-                        }
-                    }
+                if (lastNumber > latestBlock) {
+                    latestBlock = lastNumber
+                    updateLatestBlock(latestBlock.toUInt())
+                    showSnackbar("New block mined! $latestBlock \uD83C\uDF89\uD83C\uDF89")
                 }
             }
         }


### PR DESCRIPTION
This PR updates changes that need to be made for the bindings upcoming release.

This should only be merged after bdk-android release. Update will also need to be made to switch from SNAPSHOT to release.