### PR TITLE
feat: display the network type on the home screen

### DIFF
--- a/src/org/bitcoindevkit/devkitwallet/presentation/ui/screens/wallet/WalletHomeScreen.kt
+++ b/src/org/bitcoindevkit/devkitwallet/presentation/ui/screens/wallet/WalletHomeScreen.kt
@@ -60,6 +60,7 @@ import com.composables.icons.lucide.Monitor
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Shield
 import kotlinx.coroutines.flow.Flow
+import org.bitcoindevkit.Network
 import org.bitcoindevkit.devkitwallet.domain.CurrencyUnit
 import org.bitcoindevkit.devkitwallet.domain.utils.formatInBtc
 import org.bitcoindevkit.devkitwallet.presentation.navigation.BlockchainClientScreen
@@ -145,7 +146,7 @@ internal fun WalletHomeScreen(
                 }
             }
             Text(
-                text = "BITCOIN",
+                text = state.network.asHomeLabel(),
                 fontSize = 14.sp,
                 color = NightGlowSubtle,
                 letterSpacing = 2.sp,
@@ -304,6 +305,15 @@ internal fun WalletHomeScreen(
         }
     }
 }
+
+private fun Network.asHomeLabel(): String =
+    when (this) {
+        Network.BITCOIN -> "BITCOIN"
+        Network.TESTNET -> "TESTNET BITCOIN"
+        Network.TESTNET4 -> "TESTNET 4 BITCOIN"
+        Network.SIGNET -> "SIGNET BITCOIN"
+        Network.REGTEST -> "REGTEST BITCOIN"
+    }
 
 @Composable
 private fun QuickAction(icon: ImageVector, label: String, tint: Color, onClick: () -> Unit) {

--- a/src/org/bitcoindevkit/devkitwallet/presentation/viewmodels/WalletViewModel.kt
+++ b/src/org/bitcoindevkit/devkitwallet/presentation/viewmodels/WalletViewModel.kt
@@ -29,7 +29,7 @@ import org.bitcoindevkit.devkitwallet.presentation.viewmodels.mvi.WalletScreenSt
 private const val TAG = "WalletViewModel"
 
 internal class WalletViewModel(private val wallet: Wallet) : ViewModel() {
-    var state: WalletScreenState by mutableStateOf(WalletScreenState())
+    var state: WalletScreenState by mutableStateOf(WalletScreenState(network = wallet.network))
         private set
 
     private val kyotoCoroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)

--- a/src/org/bitcoindevkit/devkitwallet/presentation/viewmodels/mvi/MviWalletScreen.kt
+++ b/src/org/bitcoindevkit/devkitwallet/presentation/viewmodels/mvi/MviWalletScreen.kt
@@ -5,11 +5,13 @@
 
 package org.bitcoindevkit.devkitwallet.presentation.viewmodels.mvi
 
+import org.bitcoindevkit.Network
 import org.bitcoindevkit.devkitwallet.domain.CurrencyUnit
 
 data class WalletScreenState(
     val balance: ULong = 0u,
     val unit: CurrencyUnit = CurrencyUnit.Bitcoin,
+    val network: Network = Network.SIGNET,
     val bestBlockHeight: UInt = 0u,
     val kyotoNodeStatus: CbfNodeStatus = CbfNodeStatus.Stopped,
 )


### PR DESCRIPTION
The label under the balance was hardcoded to "BITCOIN", which is misleading
on any wallet that isn't on mainnet.

This threads the wallet's network through `WalletScreenState` (seeded from
`wallet.network` when the view model builds its initial state) and renders it
under the balance, so the home screen reads "SIGNET BITCOIN", "REGTEST BITCOIN",
and so on.

Closes #59
